### PR TITLE
Clean up documents

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,0 +1,6 @@
+# History
+
+## [Unreleased]
+- Initially drafted by Alexander Logan Martin on March 21 2020.
+- Placed under the GNU Free Documentation License
+- Published [via GitHub](https://github.com/OpenStarscape/starscape-protocol) by the OpenStarscape team.

--- a/chprops.md
+++ b/chprops.md
@@ -113,12 +113,3 @@ The "universe" is an object that contains global properties about the whole syst
 
 * `objects`: Number list; the objects that are available. Not settable.
 * `time`: Number; a monotonously-increasing timestamp. Not settable.
-
-## History
-
-The following is the history of this document as recommended by the GNU Free Documentation License:
-
-* Initially written as "Changing properties protocol" by Alexander Logan Martin on March 20 2020. Not published.
-* Generally revised and placed under the GNU Free Documentation License as "Changeable Properties Protocol" by Alexander Logan Martin on March 21 2020. Published [via GitHub](https://github.com/OpenStarscape/protocol) by the OpenStarscape team.
-* Revised to improve error reporting as "Changeable Properties Protocol" by Alexander Logan Martin on March 21 2020. Published [via GitHub](https://github.com/OpenStarscape/protocol) by the OpenStarscape team.
-* Revised to improve terminology and allow reply elision as "Changeable Properties Protocol by Alexander Logan Martin on March 24 2020. Published [via GitHub](https://github.com/OpenStarscape/protocol) by the OpenStarscape team.

--- a/chprops.md
+++ b/chprops.md
@@ -3,7 +3,7 @@
 <details>
 <summary>Author and license</summary>
 
-Written by Alexander Logan Martin and published by the OpenStarscape team [via GitHub](https://github.com/OpenStarscape/protocol).
+Written by Alexander Logan Martin and published by the OpenStarscape team [via GitHub](https://github.com/OpenStarscape/starscape-protocol).
 
 Copyright (C) 2020 Alexander Logan Martin.
 Permission is granted to copy, distribute, and/or modify this document under the terms of the GNU Free Documentation License, Version 1.3 or any later version published by the Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts. A copy of the license is included in the collection containing this document.

--- a/chprops.md
+++ b/chprops.md
@@ -1,5 +1,8 @@
 # Changeable Properties Protocol
 
+<details>
+<summary>Author and license</summary>
+
 Written by Alexander Logan Martin and published by the OpenStarscape team [via GitHub](https://github.com/OpenStarscape/protocol).
 
 Copyright (C) 2020 Alexander Logan Martin.
@@ -8,6 +11,7 @@ Permission is granted to copy, distribute, and/or modify this document under the
 THERE IS NO WARRANTY FOR THIS DOCUMENT, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS, PUBLISHERS, AND ALL OTHER PARTIES PROVIDE THIS DOCUMENT "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY OF THIS DOCUMENT IS WITH ITS USER. SHOULD THIS DOCUMENT PROVE DEFECTIVE OR INCORRECT, ITS USER ASSUMES THE COST OF ALL NECESSARY CORRECTIVE ACTION OF ANY KIND.
 
 If the disclaimer of warranty provided above cannot be given local legal effect according to its terms, reviewing courts shall apply local law that most closely approximates an absolute waiver of all civil liability in connection with this document, unless an express warranty or assumption of liability accompanies a copy of this document, and then such liability shall be assumed only by the party providing such warranty or assumption of liability.
+</details>
 
 ## Introduction
 

--- a/oscore.md
+++ b/oscore.md
@@ -3,7 +3,7 @@
 <details>
 <summary>Author and license</summary>
 
-Written by Alexander Logan Martin and published by the OpenStarscape team [via GitHub](https://github.com/OpenStarscape/protocol).
+Written by Alexander Logan Martin and published by the OpenStarscape team [via GitHub](https://github.com/OpenStarscape/starscape-protocol).
 
 Copyright (C) 2020 Alexander Logan Martin.
 Permission is granted to copy, distribute, and/or modify this document under the terms of the GNU Free Documentation License, Version 1.3 or any later version published by the Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts. A copy of the license is included in the collection containing this document.

--- a/oscore.md
+++ b/oscore.md
@@ -1,5 +1,8 @@
 # OpenStarscape core
 
+<details>
+<summary>Author and license</summary>
+
 Written by Alexander Logan Martin and published by the OpenStarscape team [via GitHub](https://github.com/OpenStarscape/protocol).
 
 Copyright (C) 2020 Alexander Logan Martin.
@@ -8,6 +11,7 @@ Permission is granted to copy, distribute, and/or modify this document under the
 THERE IS NO WARRANTY FOR THIS DOCUMENT, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS, PUBLISHERS, AND ALL OTHER PARTIES PROVIDE THIS DOCUMENT "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY OF THIS DOCUMENT IS WITH ITS USER. SHOULD THIS DOCUMENT PROVE DEFECTIVE OR INCORRECT, ITS USER ASSUMES THE COST OF ALL NECESSARY CORRECTIVE ACTION OF ANY KIND.
 
 If the disclaimer of warranty provided above cannot be given local legal effect according to its terms, reviewing courts shall apply local law that most closely approximates an absolute waiver of all civil liability in connection with this document, unless an express warranty or assumption of liability accompanies a copy of this document, and then such liability shall be assumed only by the party providing such warranty or assumption of liability.
+</details>
 
 ## Introduction
 

--- a/oscore.md
+++ b/oscore.md
@@ -82,9 +82,3 @@ An object in space under power. Version 1.
 * `accel`: Object containing numbers; the `x`, `y`, and `z` components of the body's acceleration vector in megameters per second per second. May or may not be settable.
 * `quatdeltarotate`: Object containing numbers; the `n`, `i`, `j`, and `k` components of a rotation quaternion describing the body's delta-orientation change per second per second. Not settable.
 * `axangdeltarotate`: Object containing numbers; the `eliv` and `azim` angles of a unit vector and the `roll` angle of the angle-axis representation, all measured in radians per second per second, describing the body's delta-orientation change. Not settable.
-
-## History
-
-The following is the history of this document as recommended by the GNU Free Documentation License:
-
-* Initially drafted as "OpenStarscape core" by Alexander Logan Martin on March 21 2020. Published [via GitHub](https://github.com/OpenStarscape/protocol) by the OpenStarscape team.

--- a/session/seqpacket.md
+++ b/session/seqpacket.md
@@ -24,10 +24,3 @@ Unix-domain `SOCK_SEQPACKET` sockets are a sequenced, reliable, bidirectional, c
 ## Specification
 
 All of the above-described sequenced packet transports can be used with no further specification to support the Changeable Properties Protocol.
-
-## History
-
-The following is the history of this document as recommended by the GNU Free Documentation License:
-
-* Initially written as "Session layer for changing properties protocol over sequenced packets protocols" by Alexander Logan Martin on March 20 2020. Not published.
-* Generally revised and placed under the GNU Free Documentation License as "Session layer for Changeable Properties Protocol over sequenced packet transports" by Alexander Logan Martin on March 21 2020. Published [via GitHub](https://github.com/OpenStarscape/protocol) by the OpenStarscape team.

--- a/session/seqpacket.md
+++ b/session/seqpacket.md
@@ -3,7 +3,7 @@
 <details>
 <summary>Author and license</summary>
 
-Written by Alexander Logan Martin and published by the OpenStarscape team [via GitHub](https://github.com/OpenStarscape/protocol).
+Written by Alexander Logan Martin and published by the OpenStarscape team [via GitHub](https://github.com/OpenStarscape/starscape-protocol).
 
 Copyright (C) 2020 Alexander Logan Martin.
 Permission is granted to copy, distribute, and/or modify this document under the terms of the GNU Free Documentation License, Version 1.3 or any later version published by the Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts. A copy of the license is included in the collection containing this document.

--- a/session/seqpacket.md
+++ b/session/seqpacket.md
@@ -1,5 +1,8 @@
 # Session layer for Changeable Properties Protocol over sequenced packet transports
 
+<details>
+<summary>Author and license</summary>
+
 Written by Alexander Logan Martin and published by the OpenStarscape team [via GitHub](https://github.com/OpenStarscape/protocol).
 
 Copyright (C) 2020 Alexander Logan Martin.
@@ -8,6 +11,7 @@ Permission is granted to copy, distribute, and/or modify this document under the
 THERE IS NO WARRANTY FOR THIS DOCUMENT, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS, PUBLISHERS, AND ALL OTHER PARTIES PROVIDE THIS DOCUMENT "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY OF THIS DOCUMENT IS WITH ITS USER. SHOULD THIS DOCUMENT PROVE DEFECTIVE OR INCORRECT, ITS USER ASSUMES THE COST OF ALL NECESSARY CORRECTIVE ACTION OF ANY KIND.
 
 If the disclaimer of warranty provided above cannot be given local legal effect according to its terms, reviewing courts shall apply local law that most closely approximates an absolute waiver of all civil liability in connection with this document, unless an express warranty or assumption of liability accompanies a copy of this document, and then such liability shall be assumed only by the party providing such warranty or assumption of liability.
+</details>
 
 ## Background
 

--- a/session/stream.md
+++ b/session/stream.md
@@ -1,5 +1,8 @@
 # Session layer for Changeable Properties Protocol over stream transports
 
+<details>
+<summary>Author and license</summary>
+
 Written by Alexander Logan Martin and published by the OpenStarscape team [via GitHub](https://github.com/OpenStarscape/protocol).
 
 Copyright (C) 2020 Alexander Logan Martin.
@@ -8,6 +11,7 @@ Permission is granted to copy, distribute, and/or modify this document under the
 THERE IS NO WARRANTY FOR THIS DOCUMENT, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS, PUBLISHERS, AND ALL OTHER PARTIES PROVIDE THIS DOCUMENT "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY OF THIS DOCUMENT IS WITH ITS USER. SHOULD THIS DOCUMENT PROVE DEFECTIVE OR INCORRECT, ITS USER ASSUMES THE COST OF ALL NECESSARY CORRECTIVE ACTION OF ANY KIND.
 
 If the disclaimer of warranty provided above cannot be given local legal effect according to its terms, reviewing courts shall apply local law that most closely approximates an absolute waiver of all civil liability in connection with this document, unless an express warranty or assumption of liability accompanies a copy of this document, and then such liability shall be assumed only by the party providing such warranty or assumption of liability.
+</details>
 
 ## Background
 

--- a/session/stream.md
+++ b/session/stream.md
@@ -3,7 +3,7 @@
 <details>
 <summary>Author and license</summary>
 
-Written by Alexander Logan Martin and published by the OpenStarscape team [via GitHub](https://github.com/OpenStarscape/protocol).
+Written by Alexander Logan Martin and published by the OpenStarscape team [via GitHub](https://github.com/OpenStarscape/starscape-protocol).
 
 Copyright (C) 2020 Alexander Logan Martin.
 Permission is granted to copy, distribute, and/or modify this document under the terms of the GNU Free Documentation License, Version 1.3 or any later version published by the Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts. A copy of the license is included in the collection containing this document.

--- a/session/stream.md
+++ b/session/stream.md
@@ -26,10 +26,3 @@ Unix-domain `SOCK_STREAM` sockets are an inter-process communication mechanism i
 This specification provides a session layer that sits between any of the above-described stream transports and the Changeable Properties Protocol.
 
 All messages must be converted to datagrams by serializing them with no newlines. Every datagram is terminated by exactly one newline and sent to the stream. This entire process is reversed on the receiving end.
-
-## History
-
-The following is the history of this document as recommended by the GNU Free Documentation License:
-
-* Initially written as "Session layer for changing properties protocol over stream protocols" by Alexander Logan Martin on March 20 2020. Not published.
-* Generally revised and placed under the GNU Free Documentation License as "Session layer for Changeable Properties Protocol over stream transports" by Alexander Logan Martin on March 21 2020. Published [via GitHub](https://github.com/OpenStarscape/protocol) by the OpenStarscape team.


### PR DESCRIPTION
This hides the author and licensing info behind a collapsible dropdown so they're not the first thing you see when you open the document on GitHub, and removes the history sections entirely.

Once we have versions and releases we'll have a proper changelog, but that should be kept all in one place and not clutter up the individual files. For now, git history is plenty.